### PR TITLE
Fix makefile issue when running make directly

### DIFF
--- a/Tools/Build/build.sh
+++ b/Tools/Build/build.sh
@@ -1,2 +1,1 @@
-make setup
 make all

--- a/Tools/Build/makefile
+++ b/Tools/Build/makefile
@@ -1,9 +1,11 @@
-CC = g++
+CXX = g++
 APP_NAME = Chirp
 
 CXX_FLAGS =-std=c++11 $(FLAGS)
 SRC_ROOT =../../Source
 DEST_DIR =build
+
+.PHONY : all setup
 
 #Create the include dirs in a list with -I in front of each item
 INCLUDES = $(patsubst %, -I%, $(shell find $(SRC_ROOT) -type d))
@@ -18,15 +20,19 @@ SOURCE_FILES=$(notdir $(shell find $(SRC_ROOT) -name *.cpp))
 OBJECTS = $(SOURCE_FILES:%.cpp=$(DEST_DIR)/%.o)
 
 .ONESHELL:
-all: $(OBJECTS)
-	$(CC) -o $(APP_NAME) $^ $(CXX_FLAGS)	
+all: $(APP_NAME)
+
+$(OBJECTS) : setup
+
+$(APP_NAME) : $(OBJECTS)
+	$(CXX) -o $(APP_NAME) $^ $(CXX_FLAGS)	
 
 setup:
 	@echo "Making a build folder"
 	@mkdir -p $(DEST_DIR)
 
 $(DEST_DIR)/%.o: %.cpp
-	$(CC) -c $< -o $@ $(CXX_FLAGS) $(INCLUDES)
+	$(CXX) -c $< -o $@ $(CXX_FLAGS) $(INCLUDES)
 
 clean:
 	rm $(APP_NAME)

--- a/debug.sh
+++ b/debug.sh
@@ -1,5 +1,4 @@
 # this file is used to create a debuggable executable, not for debug itself
 # you run this, and use it with gdb
 cd Tools/Build
-make setup
 make FLAGS=-g all


### PR DESCRIPTION
Added dependency (in makefile) so that it is now possible to just run `make` without using `build.sh`
Also:
Marked some targets as phony in makefile.
Renamed CC var to CXX